### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/all_material/check_compliance/requirements.txt
+++ b/all_material/check_compliance/requirements.txt
@@ -1,6 +1,6 @@
 # ────────────── core ──────────────
-pyautogen==0.4.*        # Microsoft AutoGen v0.4（含 autogen_core / agentchat / ext）
-openai>=1.17.0          # OpenAI Python SDK（pyautogen 仍會間接用到）
+ag2==0.4.*        # Microsoft AutoGen v0.4（含 autogen_core / agentchat / ext）
+openai>=1.17.0          # OpenAI Python SDK（ag2 仍會間接用到）
 
 # ────────────── async MySQL ──────────────
 aiomysql>=0.2.0,<1.0    # 非同步 MySQL driver，適用 PyMySQL 後端

--- a/all_material/requirements.txt
+++ b/all_material/requirements.txt
@@ -87,8 +87,8 @@ json5>=0.9.14
 
 # check_compliance:
 # ────────────── core ──────────────
-pyautogen==0.4.*        # Microsoft AutoGen v0.4（含 autogen_core / agentchat / ext）
-openai>=1.17.0          # OpenAI Python SDK（pyautogen 仍會間接用到）
+ag2==0.4.*        # Microsoft AutoGen v0.4（含 autogen_core / agentchat / ext）
+openai>=1.17.0          # OpenAI Python SDK（ag2 仍會間接用到）
 
 # ────────────── async MySQL ──────────────
 aiomysql>=0.2.0,<1.0    # 非同步 MySQL driver，適用 PyMySQL 後端


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
